### PR TITLE
Chunk mismatch warning only

### DIFF
--- a/read.go
+++ b/read.go
@@ -52,7 +52,8 @@ func readChunks(ch <-chan bson.D, o chan<- Chunk, abrt <-chan bool) error {
 			nmetrics := unpackInt(bl[:4])
 			ndeltas := unpackInt(bl[4:])
 			if nmetrics != len(metrics) {
-				return fmt.Errorf("metrics mismatch. Expected %d, got %d", nmetrics, len(metrics))
+				//return fmt.Errorf("metrics mismatch. Expected %d, got %d", nmetrics, len(metrics))
+				fmt.Printf("Warning: metrics mismatch. Expected %d, got %d\n", nmetrics, len(metrics))
 			}
 			nzeroes := 0
 			for i, v := range metrics {

--- a/read.go
+++ b/read.go
@@ -6,6 +6,7 @@ import (
 	"compress/zlib"
 	"fmt"
 	"io"
+	"os"
 
 	"gopkg.in/mgo.v2/bson"
 )
@@ -53,7 +54,7 @@ func readChunks(ch <-chan bson.D, o chan<- Chunk, abrt <-chan bool) error {
 			ndeltas := unpackInt(bl[4:])
 			if nmetrics != len(metrics) {
 				//return fmt.Errorf("metrics mismatch. Expected %d, got %d", nmetrics, len(metrics))
-				fmt.Printf("Warning: metrics mismatch. Expected %d, got %d\n", nmetrics, len(metrics))
+				fmt.Fprintf(os.Stderr, "Warning: metrics mismatch. Expected %d, got %d\n", nmetrics, len(metrics))
 			}
 			nzeroes := 0
 			for i, v := range metrics {

--- a/read.go
+++ b/read.go
@@ -53,7 +53,6 @@ func readChunks(ch <-chan bson.D, o chan<- Chunk, abrt <-chan bool) error {
 			nmetrics := unpackInt(bl[:4])
 			ndeltas := unpackInt(bl[4:])
 			if nmetrics != len(metrics) {
-				//return fmt.Errorf("metrics mismatch. Expected %d, got %d", nmetrics, len(metrics))
 				fmt.Fprintf(os.Stderr, "Warning: metrics mismatch. Expected %d, got %d\n", nmetrics, len(metrics))
 			}
 			nzeroes := 0


### PR DESCRIPTION
Changes the 'chunk count mismatch' error to a warning.  This is due to issues found with the FTDC output from 3.2.15.